### PR TITLE
fix: SDR Marked Enabled on boot

### DIFF
--- a/aiov2_ctl.py
+++ b/aiov2_ctl.py
@@ -614,7 +614,7 @@ class GpioController:
     @staticmethod
     def get_gpio(pin):
         out = GpioController.run(["pinctrl", "get", str(pin)])
-        return bool(out and "hi" in out)
+        return bool(out and ("hi" in out or "pu" in out))
 
 # ==============================
 # Telemetry
@@ -931,6 +931,7 @@ def run_gui():
     for f in GPIO_MAP:
         a = QAction(f)
         a.setCheckable(True)
+        cb.setChecked(GpioController.get_gpio(GPIO_MAP.get(f)))
         a.triggered.connect(
             lambda checked, f=f: GpioController.set_feature(f, checked)
         )
@@ -961,6 +962,7 @@ def run_gui():
     checkboxes = {}
     for f in GPIO_MAP:
         cb = QCheckBox(f)
+        cb.setChecked(GpioController.get_gpio(GPIO_MAP.get(f)))
         cb.toggled.connect(
             lambda checked, f=f: GpioController.set_feature(f, checked)
         )

--- a/aiov2_ctl.py
+++ b/aiov2_ctl.py
@@ -611,10 +611,20 @@ class GpioController:
                     GpioController._run_service("stop")
                 disable_mesh_autostart_if_default(announce=False)
 
+    # 7 
+    # boot: no    pu | --
+    # on:   op dh pu | hi
+    # off:  op dl pu | lo
+
+    # 16, 23, 27
+    # boot: no    pd | --
+    # on:   op dh pd | hi
+    # off:  op dl pd | lo
+
     @staticmethod
     def get_gpio(pin):
         out = GpioController.run(["pinctrl", "get", str(pin)])
-        return bool(out and ("hi" in out or "pu" in out))
+        return bool(out and ("hi" in out or "no    pu" in out))
 
 # ==============================
 # Telemetry

--- a/aiov2_ctl.py
+++ b/aiov2_ctl.py
@@ -611,15 +611,18 @@ class GpioController:
                     GpioController._run_service("stop")
                 disable_mesh_autostart_if_default(announce=False)
 
+   
+
+    # Pin States
     # 7 
-    # boot: no    pu | --
-    # on:   op dh pu | hi
-    # off:  op dl pu | lo
+    # boot (on): no    pu | --
+    # on:        op dh pu | hi
+    # off:       op dl pu | lo
 
     # 16, 23, 27
-    # boot: no    pd | --
-    # on:   op dh pd | hi
-    # off:  op dl pd | lo
+    # boot (off): no    pd | --
+    # on:         op dh pd | hi
+    # off:        op dl pd | lo
 
     @staticmethod
     def get_gpio(pin):

--- a/aiov2_ctl.py
+++ b/aiov2_ctl.py
@@ -931,7 +931,7 @@ def run_gui():
     for f in GPIO_MAP:
         a = QAction(f)
         a.setCheckable(True)
-        cb.setChecked(GpioController.get_gpio(GPIO_MAP.get(f)))
+        a.setChecked(GpioController.get_gpio(GPIO_MAP.get(f)))
         a.triggered.connect(
             lambda checked, f=f: GpioController.set_feature(f, checked)
         )


### PR DESCRIPTION
Per the docs [here](https://hackergadgets.com/pages/hackergadgets-uconsole-rtl-sdr-lora-gps-rtc-usb-hub-all-in-one-extension-board-setup-guide) SDR is enabled by default.
Indeed i can run use SDR on boot without any changes.

This fix adds an additional check for pin 7 on boot and marks it as enabled.

I have done limited testing but this seems to work and properly show the SDR status after boot as well as does not effect the ability to disable and enable SDR.

I am unsure why the pin on state after enabling it does not match the pin on state from boot, but regardless SDR works on boot.